### PR TITLE
Update Dependabot cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,11 @@ updates:
       time: '14:00'
     open-pull-requests-limit: 10
     cooldown:
-      default-days: 4
+      default-days: 7
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
       time: '14:00'
     cooldown:
-      default-days: 4
+      default-days: 7


### PR DESCRIPTION
## Summary
- Updates Dependabot cooldown from 4 days to 7 days
- Addresses zizmor `dependabot-cooldown` finding

## Test plan
- [x] zizmor reports no cooldown findings after change