### PR TITLE
Add workflow to check for updates to pseudo-versioned dependencies

### DIFF
--- a/.github/workflows/check-untagged-deps.yml
+++ b/.github/workflows/check-untagged-deps.yml
@@ -1,0 +1,20 @@
+name: Check Untagged Dependencies
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: horgh/check-untagged-go-deps@b2bec8a7a0c8da55e64b092013f7bf5dff1006ca # v1.0.1


### PR DESCRIPTION
## Summary

- Add GitHub Action workflow to check for updates to pseudo-versioned (commit-pinned) Go dependencies

Dependabot does not support updating Go dependencies pinned to commits (pseudo-versions). This workflow fills that gap by checking if newer commits are available on the default branch.

See: https://github.com/dependabot/dependabot-core/issues/2028

## Test plan

- [ ] Verify workflow runs successfully on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)