### PR TITLE
Pin GitHub Actions to SHA for security

### DIFF
--- a/.github/workflows/check-untagged-deps.yml
+++ b/.github/workflows/check-untagged-deps.yml
@@ -13,7 +13,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Docker
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
       - name: Download test database

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,7 +15,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

- Pin official GitHub Actions (`actions/*`, `github/*`) to specific commit SHAs
- Satisfies zizmor's `unpinned-action-reference` security check
- All actions upgraded to latest versions

## Changes

Updates workflow files to use pinned SHA references instead of version tags:
- `actions/checkout@v6` → `actions/checkout@<sha> # v6.0.1`
- `github/codeql-action/*@v4` → `github/codeql-action/*@<sha> # v4.31.9`
- And similar for other official actions

## Test plan

- [ ] CI passes with pinned actions
- [ ] zizmor check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)